### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-inst/tutorials/* linguist-vendored
+inst/tutorials/* linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+inst/tutorials/* linguist-vendored


### PR DESCRIPTION
This removes HTML tutorial files from the repo statistics.

I tried to look for this repo with the following search https://github.com/search?l=r&q=genius&type=Repositories but couldn't find it because GitHub sees it as a HTML repo. The present PR should fix this.

Documentation: https://github.com/github/linguist#overrides