### PR TITLE
fix genius_album for info = "title" and info - "all", add album_name …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Title: Easily access song lyrics from Genius.com
 Version: 2.2.1
 Authors@R: c(
   person("Josiah", "Parry", email = "josiah.parry@gmail.com", role = c("aut", "cre")),
-  person("Nathan", "Barr", email = "nab222@cornell.edu", role = "ctb")
+  person("Nathan", "Barr", email = "nab222@cornell.edu", role = "ctb"),
+  person("Chris", "Billingham", email = "chris.billingham@gmail.com", role = "ctb")
   )
 Description: Easily access song lyrics in a tidy way.
 URL: https://github.com/josiahparry/genius

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 Nov 27th, 2019
 
-* Thank you to [\@mine-cetinkaya-rundel](https://github.com/mine-cetinkaya-rundel) for noting changes to `tidyr::unnest()` producing unwanted warnings in `add_genius()`. This has been fixed
+* Thank you to [\@mine-cetinkaya-rundel](https://github.com/mine-cetinkaya-rundel) for noting changes to `tidyr::unnest()` producing unwanted warnings in `add_genius()`. This has been fixed.
+* Thank you to [\@chris-billingham](https://github.com/chris-billingham) for noting issues with the `info = "title"` and `info = "all"` arguments of `genius_album()` and fixing these whilst also adding album_name into the output from `genius_album(..., info = "all")`.
 
 
 

--- a/R/genius_album.R
+++ b/R/genius_album.R
@@ -6,13 +6,13 @@ if(getRversion() >= "2.15.1")  utils::globalVariables(c("track_url", "lyrics"))
 #'
 #' @param artist The quoted name of the artist. Spelling matters, capitalization does not.
 #' @param album The quoted name of the album Spelling matters, capitalization does not.
-#' @param info Return extra information about each song. Default `"simple"` returns `title`, `track_n`, and `text`. Set `info = "artist"` for artist and track title. See args to `genius_lyrics()`.
+#' @param info Return extra information about each song. Default `"simple"` returns title`, `track_n`, and `text`. Set `info = "artist"` for artist and track title and `info = "all"` for all possible columns plus adds the album name. See args to `genius_lyrics()`.
 #'
 #' @examples
 #'
 #'\dontrun{
 #' genius_album(artist = "Petal", album = "Comfort EP")
-#' genius_album(artist = "Fit For A King", album = "Deathgrip")
+#' genius_album(artist = "Fit For A King", album = "Deathgrip", info = "all")
 #'}
 #'
 #' @export
@@ -27,10 +27,12 @@ genius_album <- function(artist = NULL, album = NULL, info = "simple") {
 
   album <- tracks %>%
     mutate(lyrics = map(track_url, possible_url, info)) %>%
+    select(-track_title) %>%
     unnest(lyrics) %>%
     right_join(tracks) %>%
     select(-track_url)
 
+  if(info != "all"){album <- album %>% select(-album_name)}
 
   return(album)
 }

--- a/R/genius_album.R
+++ b/R/genius_album.R
@@ -6,7 +6,15 @@ if(getRversion() >= "2.15.1")  utils::globalVariables(c("track_url", "lyrics"))
 #'
 #' @param artist The quoted name of the artist. Spelling matters, capitalization does not.
 #' @param album The quoted name of the album Spelling matters, capitalization does not.
-#' @param info Return extra information about each song. Default `"simple"` returns title`, `track_n`, and `text`. Set `info = "artist"` for artist and track title and `info = "all"` for all possible columns plus adds the album name. See args to `genius_lyrics()`.
+#' @param info Return track level metadata. See details.
+#'
+#' @details
+#' The `info` argument returns additional columns to the returned tibble:
+#' `"simple"` returns only the song lyrics.
+#' `"title"` returns the track title and lyrics.
+#' `"artist"` returns the lyrics and artist.
+#' `"features"` returns the lyrics, song elements, and element artists.
+#' `"all"` returns all of the above mentioned, plus appends the album name.
 #'
 #' @examples
 #'

--- a/R/genius_tracklist.R
+++ b/R/genius_tracklist.R
@@ -21,6 +21,10 @@ genius_tracklist <- function(artist = NULL, album = NULL) {
   url <- gen_album_url(artist, album)
   session <- html_session(url)
 
+  # Get the album name
+  album_name <- html_nodes(session, ".header_with_cover_art-primary_info-title") %>%
+    html_text()
+
   # Get track numbers
   # Where there are no track numbers, it isn't a song
   track_numbers <- html_nodes(session, ".chart_row-number_container-number") %>%
@@ -45,6 +49,7 @@ genius_tracklist <- function(artist = NULL, album = NULL) {
   # Create df for easy filtering
   # Filter to find only the actual tracks, the ones without a track number were credits / booklet etc
   df <- tibble(
+    album_name = album_name,
     track_title = track_titles,
     track_n = as.integer(track_numbers),
     track_url = track_url

--- a/man/genius_album.Rd
+++ b/man/genius_album.Rd
@@ -11,7 +11,7 @@ genius_album(artist = NULL, album = NULL, info = "simple")
 
 \item{album}{The quoted name of the album Spelling matters, capitalization does not.}
 
-\item{info}{Return extra information about each song. Default `"simple"` returns `title`, `track_n`, and `text`. Set `info = "artist"` for artist and track title. See args to `genius_lyrics()`.}
+\item{info}{Return extra information about each song. Default `"simple"` returns title`, `track_n`, and `text`. Set `info = "artist"` for artist and track title and `info = "all"` for all possible columns plus adds the album name. See args to `genius_lyrics()`.}
 }
 \description{
 Obtain the lyrics to an album in a tidy format.
@@ -20,7 +20,7 @@ Obtain the lyrics to an album in a tidy format.
 
 \dontrun{
 genius_album(artist = "Petal", album = "Comfort EP")
-genius_album(artist = "Fit For A King", album = "Deathgrip")
+genius_album(artist = "Fit For A King", album = "Deathgrip", info = "all")
 }
 
 }

--- a/man/genius_album.Rd
+++ b/man/genius_album.Rd
@@ -11,10 +11,18 @@ genius_album(artist = NULL, album = NULL, info = "simple")
 
 \item{album}{The quoted name of the album Spelling matters, capitalization does not.}
 
-\item{info}{Return extra information about each song. Default `"simple"` returns title`, `track_n`, and `text`. Set `info = "artist"` for artist and track title and `info = "all"` for all possible columns plus adds the album name. See args to `genius_lyrics()`.}
+\item{info}{Return track level metadata. See details.}
 }
 \description{
 Obtain the lyrics to an album in a tidy format.
+}
+\details{
+The `info` argument returns additional columns to the returned tibble:
+`"simple"` returns only the song lyrics.
+`"title"` returns the track title and lyrics.
+`"artist"` returns the lyrics and artist.
+`"features"` returns the lyrics, song elements, and element artists.
+`"all"` returns all of the above mentioned, plus appends the album name.
 }
 \examples{
 


### PR DESCRIPTION
Hey,

So initally this was just a little fix to sort the duplicate track_title in genius_album, which was a pretty simple fix. But then setting to `info = "all"` didn't pull through the album_name as we discussed at [https://github.com/chris-billingham/battle_of_the_bands/issues/1](url) so I've added a scrape for that into genius_tracklist which is then pulled through.